### PR TITLE
[feat] Firebase auth(email) setup

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -108,8 +108,19 @@ PODS:
     - React-Core (= 0.72.3)
     - React-jsi (= 0.72.3)
     - ReactCommon/turbomodule/core (= 0.72.3)
+  - Firebase/Auth (10.14.0):
+    - Firebase/CoreOnly
+    - FirebaseAuth (~> 10.14.0)
   - Firebase/CoreOnly (10.14.0):
     - FirebaseCore (= 10.14.0)
+  - FirebaseAppCheckInterop (10.14.0)
+  - FirebaseAuth (10.14.0):
+    - FirebaseAppCheckInterop (~> 10.0)
+    - FirebaseCore (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.8)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GTMSessionFetcher/Core (< 4.0, >= 2.1)
+    - RecaptchaInterop (~> 100.0)
   - FirebaseCore (10.14.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
@@ -118,11 +129,22 @@ PODS:
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - fmt (6.2.1)
   - glog (0.3.5)
+  - GoogleUtilities/AppDelegateSwizzler (7.11.5):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
   - GoogleUtilities/Environment (7.11.5):
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/Logger (7.11.5):
     - GoogleUtilities/Environment
+  - GoogleUtilities/Network (7.11.5):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
   - "GoogleUtilities/NSData+zlib (7.11.5)"
+  - GoogleUtilities/Reachability (7.11.5):
+    - GoogleUtilities/Logger
+  - GTMSessionFetcher/Core (3.1.1)
   - hermes-engine (0.72.3):
     - hermes-engine/Pre-built (= 0.72.3)
   - hermes-engine/Pre-built (0.72.3)
@@ -545,11 +567,16 @@ PODS:
     - React-jsi (= 0.72.3)
     - React-logger (= 0.72.3)
     - React-perflogger (= 0.72.3)
+  - RecaptchaInterop (100.0.0)
   - RNCAsyncStorage (1.18.2):
     - React-Core
   - RNFBApp (18.3.1):
     - Firebase/CoreOnly (= 10.14.0)
     - React-Core
+  - RNFBAuth (18.3.1):
+    - Firebase/Auth (= 10.14.0)
+    - React-Core
+    - RNFBApp
   - RNGestureHandler (2.12.1):
     - React-Core
   - RNReanimated (3.3.0):
@@ -653,6 +680,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNFBApp (from `../node_modules/@react-native-firebase/app`)"
+  - "RNFBAuth (from `../node_modules/@react-native-firebase/auth`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -663,13 +691,17 @@ SPEC REPOS:
   trunk:
     - ASN1Decoder
     - Firebase
+    - FirebaseAppCheckInterop
+    - FirebaseAuth
     - FirebaseCore
     - FirebaseCoreInternal
     - fmt
     - GoogleUtilities
+    - GTMSessionFetcher
     - libevent
     - PromisesObjC
     - ReachabilitySwift
+    - RecaptchaInterop
     - SocketRocket
 
 EXTERNAL SOURCES:
@@ -796,6 +828,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-async-storage/async-storage"
   RNFBApp:
     :path: "../node_modules/@react-native-firebase/app"
+  RNFBAuth:
+    :path: "../node_modules/@react-native-firebase/auth"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
@@ -834,11 +868,14 @@ SPEC CHECKSUMS:
   FBLazyVector: 4cce221dd782d3ff7c4172167bba09d58af67ccb
   FBReactNativeSpec: c6bd9e179757b3c0ecf815864fae8032377903ef
   Firebase: 6c1bf3f534bc422d52af2e41fe0d50bf08b6b773
+  FirebaseAppCheckInterop: c87f1d5421c852413dd936b2b2340b21e62501a0
+  FirebaseAuth: bd1ae3d28beb83bfe9247e50eb82688b683dd770
   FirebaseCore: 6fc17ac9f03509d51c131298aacb3ee5698b4f02
   FirebaseCoreInternal: d558159ee6cc4b823c2296ecc193de9f6d9a5bb3
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
+  GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
   hermes-engine: 10fbd3f62405c41ea07e71973ea61e1878d07322
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
@@ -876,8 +913,10 @@ SPEC CHECKSUMS:
   React-runtimescheduler: 22227c2d5e0dddee3053218f4ed75f237a856a47
   React-utils: d0137564ad2eb7b27211bfa52a891f9b4b5c9d1f
   ReactCommon: 4ebd5007c0384340e7bcdf687a191c65bf269314
+  RecaptchaInterop: 7d1a4a01a6b2cb1610a47ef3f85f0c411434cb21
   RNCAsyncStorage: ddc4ee162bfd41b0d2c68bf2d95acd81dd7f1f93
   RNFBApp: 73795c4680eba994f9639c6bb8e0aed3c0a14394
+  RNFBAuth: 76ee6c9adf962127fab3ed88d26d4caf6f435812
   RNGestureHandler: c0d04458598fcb26052494ae23dda8f8f5162b13
   RNReanimated: 9f7068e43b9358a46a688d94a5a3adb258139457
   RNScreens: 50ffe2fa2342eabb2d0afbe19f7c1af286bc7fb3

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@expo/vector-icons": "^13.0.0",
     "@react-native-async-storage/async-storage": "1.18.2",
     "@react-native-firebase/app": "^18.3.1",
+    "@react-native-firebase/auth": "^18.3.1",
     "@react-navigation/bottom-tabs": "^6.5.8",
     "@react-navigation/native": "^6.0.2",
     "@react-navigation/native-stack": "^6.9.13",

--- a/src/components/providers/AuthProvider.tsx
+++ b/src/components/providers/AuthProvider.tsx
@@ -1,8 +1,10 @@
+import { FirebaseAuthTypes } from '@react-native-firebase/auth';
 import { createContext, ReactNode, useContext, useState } from 'react';
 
 type AuthContextValue = {
   isAuthenticated: boolean;
-  signIn: () => void;
+  user: FirebaseAuthTypes.User | null;
+  signIn: (authUser: FirebaseAuthTypes.User) => void;
   signOut: () => void;
 };
 
@@ -10,24 +12,32 @@ const AuthContext = createContext({} as AuthContextValue);
 
 type AuthProviderProps = {
   children: ReactNode;
-  value: Pick<AuthContextValue, 'isAuthenticated'>;
+  value: Pick<AuthContextValue, 'isAuthenticated' | 'user'>;
 };
 
 export const AuthProvider = ({ children, value }: AuthProviderProps) => {
-  const [isAuthenticated, setIsAuthenticated] = useState<boolean>(
-    value.isAuthenticated
-  );
+  const [authState, setAuthState] = useState<{
+    user: FirebaseAuthTypes.User | null;
+    isAuthenticated: boolean;
+  }>(value);
 
-  const signIn = () => {
-    setIsAuthenticated((prev) => !prev);
+  const signIn = (authUser: FirebaseAuthTypes.User) => {
+    setAuthState({ user: authUser, isAuthenticated: true });
   };
 
   const signOut = () => {
-    setIsAuthenticated((prev) => !prev);
+    setAuthState({ user: null, isAuthenticated: false });
   };
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, signIn, signOut }}>
+    <AuthContext.Provider
+      value={{
+        isAuthenticated: authState.isAuthenticated,
+        user: authState.user,
+        signIn,
+        signOut,
+      }}
+    >
       {children}
     </AuthContext.Provider>
   );

--- a/src/components/screens/SignIn/SignIn.tsx
+++ b/src/components/screens/SignIn/SignIn.tsx
@@ -5,33 +5,53 @@ import {
   createAreniteStyle,
   Divider,
   SafeAreaView,
+  useToast,
   VStack,
 } from 'arenite-kit';
 
 import { useAuth } from '$components/providers/AuthProvider';
 import { SignForm, SignFormValue } from '$components/shared/form/SignForm';
 import { ThemingIcon } from '$components/shared/ThemingIcon';
+import { ToastId } from '$libs/arenite-kit/toastId';
+import { firebaseAuth } from '$libs/firebase/auth';
 import { getSafeAreaEdges } from '$libs/react-native-safe-area-context/getSafeAreaEdges';
 import { RootParamList } from '$navigation/navigate';
 
+const { signInWithEmail, catchFirebaseAuthError } = firebaseAuth;
+
 export const SignInScreen = () => {
   const { signIn } = useAuth();
+  const toast = useToast();
   const navigation = useNavigation<NavigationProp<RootParamList>>();
   const edges = getSafeAreaEdges('horizontal');
 
   const onPressSignInWithAppleButton = () => {
-    signIn();
     navigation.navigate('AppNavigator');
   };
 
   const onPressSignInWithGoogleButton = () => {
-    signIn();
     navigation.navigate('AppNavigator');
   };
 
-  const onPressSignInButton = (_formValues: SignFormValue) => {
-    signIn();
-    navigation.navigate('AppNavigator');
+  const onPressSignInButton = async (formValues: SignFormValue) => {
+    try {
+      const result = await signInWithEmail(formValues);
+      signIn(result.user);
+
+      navigation.navigate('AppNavigator');
+      toast.addToast({
+        id: ToastId.SignInEmailSuccess,
+        type: 'success',
+        message: 'サインインに成功しました',
+      });
+    } catch (error) {
+      const errorMessage = catchFirebaseAuthError(error);
+      toast.addToast({
+        id: ToastId.SignInEmailError,
+        type: 'error',
+        message: errorMessage,
+      });
+    }
   };
 
   return (

--- a/src/components/screens/SignUp/SignUp.tsx
+++ b/src/components/screens/SignUp/SignUp.tsx
@@ -9,24 +9,20 @@ import {
   VStack,
 } from 'arenite-kit';
 
-import { useAuth } from '$components/providers/AuthProvider';
 import { ThemingIcon } from '$components/shared/ThemingIcon';
 import { getSafeAreaEdges } from '$libs/react-native-safe-area-context/getSafeAreaEdges';
 import { AuthNavigatorParamList, RootParamList } from '$navigation/navigate';
 
 export const SignUpScreen = () => {
-  const { signIn } = useAuth();
   const navigation =
     useNavigation<NavigationProp<RootParamList & AuthNavigatorParamList>>();
   const edges = getSafeAreaEdges('horizontal');
 
   const onPressContinueWithAppleButton = () => {
-    signIn();
     navigation.navigate('AppNavigator');
   };
 
   const onPressContinueWithGoogleButton = () => {
-    signIn();
     navigation.navigate('AppNavigator');
   };
 

--- a/src/components/screens/SignUpWithEmail/SignUpWithEmail.tsx
+++ b/src/components/screens/SignUpWithEmail/SignUpWithEmail.tsx
@@ -1,25 +1,46 @@
 import { useNavigation } from '@react-navigation/core';
 import { NavigationProp } from '@react-navigation/core/src/types';
-import { createAreniteStyle, SafeAreaView } from 'arenite-kit';
+import { createAreniteStyle, SafeAreaView, useToast } from 'arenite-kit';
 
 import { useAuth } from '$components/providers/AuthProvider';
 import { SignForm, SignFormValue } from '$components/shared/form/SignForm';
+import { ToastId } from '$libs/arenite-kit/toastId';
+import { firebaseAuth } from '$libs/firebase/auth';
 import { getSafeAreaEdges } from '$libs/react-native-safe-area-context/getSafeAreaEdges';
 import { RootParamList } from '$navigation/navigate';
 
+const { signUpWithEmail, catchFirebaseAuthError } = firebaseAuth;
+
 export const SignUpWithEmailScreen = () => {
   const { signIn } = useAuth();
+  const toast = useToast();
   const navigation = useNavigation<NavigationProp<RootParamList>>();
   const edges = getSafeAreaEdges('horizontal');
 
-  const onPressSignUpButton = (_formValues: SignFormValue) => {
-    signIn();
-    navigation.navigate('AppNavigator');
+  const onPressSignUpButton = async (values: SignFormValue) => {
+    try {
+      const result = await signUpWithEmail(values);
+      signIn(result.user);
+
+      navigation.navigate('AppNavigator');
+      toast.addToast({
+        id: ToastId.SignUpEmailSuccess,
+        type: 'success',
+        message: 'サインアップに成功しました',
+      });
+    } catch (error) {
+      const errorMessage = catchFirebaseAuthError(error);
+      toast.addToast({
+        id: ToastId.SignUpEmailError,
+        type: 'error',
+        message: errorMessage,
+      });
+    }
   };
 
   return (
     <SafeAreaView style={style.container} edges={edges} bg={'bg1'}>
-      <SignForm formType={'sign-in'} onSubmit={onPressSignUpButton} />
+      <SignForm formType={'sign-up'} onSubmit={onPressSignUpButton} />
     </SafeAreaView>
   );
 };

--- a/src/components/screens/SignUpWithEmail/SignUpWithEmail.tsx
+++ b/src/components/screens/SignUpWithEmail/SignUpWithEmail.tsx
@@ -7,7 +7,7 @@ import { SignForm, SignFormValue } from '$components/shared/form/SignForm';
 import { getSafeAreaEdges } from '$libs/react-native-safe-area-context/getSafeAreaEdges';
 import { RootParamList } from '$navigation/navigate';
 
-export const SignInWithEmailScreen = () => {
+export const SignUpWithEmailScreen = () => {
   const { signIn } = useAuth();
   const navigation = useNavigation<NavigationProp<RootParamList>>();
   const edges = getSafeAreaEdges('horizontal');

--- a/src/navigation/app/index.tsx
+++ b/src/navigation/app/index.tsx
@@ -1,11 +1,13 @@
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/core';
 import { NavigationProp } from '@react-navigation/core/src/types';
-import { IconButton } from 'arenite-kit';
+import { IconButton, useToast } from 'arenite-kit';
 import { Alert } from 'react-native';
 
 import { useAuth } from '$components/providers/AuthProvider';
 import { ThemingIcon } from '$components/shared/ThemingIcon';
+import { ToastId } from '$libs/arenite-kit/toastId';
+import { firebaseAuth } from '$libs/firebase/auth';
 import { ComponentsNavigator } from '$navigation/app/components';
 import { ThemingNavigator } from '$navigation/app/theming';
 import type { AppNavigatorParamList } from '$navigation/navigate';
@@ -56,8 +58,11 @@ export const AppNavigator = () => {
   );
 };
 
+const { signOut: firebaseSignOut } = firebaseAuth;
+
 const SignInStatusIconButton = () => {
   const { isAuthenticated, signOut } = useAuth();
+  const toast = useToast();
   const navigation = useNavigation<NavigationProp<RootParamList>>();
 
   const onPressNavigateAuth = () => {
@@ -68,7 +73,27 @@ const SignInStatusIconButton = () => {
 
     Alert.alert('Sign Out', 'Are you sure?', [
       { text: 'Cancel', style: 'cancel' },
-      { text: 'OK', style: 'default', onPress: () => signOut() },
+      {
+        text: 'OK',
+        style: 'default',
+        onPress: async () => {
+          try {
+            await firebaseSignOut();
+            signOut();
+            toast.addToast({
+              id: ToastId.SignOutSuccess,
+              type: 'success',
+              message: 'サインアウトしました',
+            });
+          } catch {
+            toast.addToast({
+              id: ToastId.SignOutError,
+              type: 'error',
+              message: 'サインアウトに失敗しました',
+            });
+          }
+        },
+      },
     ]);
   };
 

--- a/src/navigation/auth.tsx
+++ b/src/navigation/auth.tsx
@@ -1,8 +1,8 @@
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import { SignInScreen } from '$components/screens/SignIn/SignIn';
-import { SignInWithEmailScreen } from '$components/screens/SignInWithEmail/SignInWithEmail';
 import { SignUpScreen } from '$components/screens/SignUp/SignUp';
+import { SignUpWithEmailScreen } from '$components/screens/SignUpWithEmail/SignUpWithEmail';
 import { AuthNavigatorParamList } from '$navigation/navigate';
 
 const NativeStack = createNativeStackNavigator<AuthNavigatorParamList>();
@@ -17,7 +17,7 @@ export const AuthNavigator = () => {
       />
       <NativeStack.Screen
         name="SignUpWithEmailScreen"
-        component={SignInWithEmailScreen}
+        component={SignUpWithEmailScreen}
         options={{ title: 'Sign up with Email' }}
       />
       <NativeStack.Screen

--- a/src/shared/hooks/useAppBootstrap.ts
+++ b/src/shared/hooks/useAppBootstrap.ts
@@ -1,3 +1,4 @@
+import auth, { FirebaseAuthTypes } from '@react-native-firebase/auth';
 import type { AreniteTheme, AreniteThemeKey } from 'arenite-kit';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect, useState } from 'react';
@@ -6,10 +7,13 @@ import { areniteThemeStorageKey } from '$constants/asyncStorageKeys';
 import { myThemePalettes } from '$libs/arenite-kit/areniteConfig';
 import { asyncStorage } from '$libs/react-native-async-storage/asyncStorage';
 
+type FirebaseUser = FirebaseAuthTypes.User | null;
+
 SplashScreen.preventAutoHideAsync();
 
 export const useAppBootstrap = () => {
   const [isAuthenticated] = useState(false);
+  const [user, setUser] = useState<FirebaseUser>(null);
   const [isReady, setIsReady] = useState(false);
   const [userTheme, setUserTheme] = useState<AreniteThemeKey>('auto');
 
@@ -33,10 +37,18 @@ export const useAppBootstrap = () => {
     };
 
     prepare().then();
+
+    const subscribe = auth().onAuthStateChanged(
+      (firebaseUser: FirebaseUser) => {
+        setUser(firebaseUser);
+      }
+    );
+    return subscribe;
   }, []);
 
   const authValue = {
     isAuthenticated,
+    user,
   };
 
   const themeValue: AreniteTheme = {

--- a/src/shared/libs/arenite-kit/toastId.ts
+++ b/src/shared/libs/arenite-kit/toastId.ts
@@ -1,0 +1,6 @@
+export const ToastId = {
+  SignInEmailSuccess: 'SIGN_IN_EMAIL_SUCCESS',
+  SignInEmailError: 'SIGN_IN_EMAIL_ERROR',
+  SignUpEmailSuccess: 'SIGN_UP_EMAIL_SUCCESS',
+  SignUpEmailError: 'SIGN_UP_EMAIL_ERROR',
+} as const;

--- a/src/shared/libs/arenite-kit/toastId.ts
+++ b/src/shared/libs/arenite-kit/toastId.ts
@@ -3,4 +3,6 @@ export const ToastId = {
   SignInEmailError: 'SIGN_IN_EMAIL_ERROR',
   SignUpEmailSuccess: 'SIGN_UP_EMAIL_SUCCESS',
   SignUpEmailError: 'SIGN_UP_EMAIL_ERROR',
+  SignOutSuccess: 'SIGN_OUT_SUCCESS',
+  SignOutError: 'SIGN_OUT_ERROR',
 } as const;

--- a/src/shared/libs/firebase/auth.ts
+++ b/src/shared/libs/firebase/auth.ts
@@ -1,0 +1,71 @@
+import { ReactNativeFirebase } from '@react-native-firebase/app';
+import auth, { FirebaseAuthTypes } from '@react-native-firebase/auth';
+
+type FirebaseError = ReactNativeFirebase.NativeFirebaseError;
+
+const isFirebaseError = (error: unknown): error is FirebaseError => {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    'message' in error
+  );
+};
+
+const catchFirebaseAuthError = (error: unknown) => {
+  if (isFirebaseError(error)) {
+    switch (error.code) {
+      case 'auth/email-already-in-use':
+        return '既に使用されているメールアドレスです';
+      case 'auth/invalid-email':
+        return '無効なメールアドレスです';
+      case 'auth/weak-password':
+        return 'パスワードは6文字以上で入力してください';
+      case 'auth/user-not-found':
+      case 'auth/wrong-password':
+        return 'メールアドレスまたはパスワードが間違っています';
+      case 'auth/user-disabled':
+        return 'このアカウントは無効になっています';
+      case 'auth/too-many-requests':
+        return '短時間に多くのリクエストがありました。後ほど再試行してください';
+      case 'auth/operation-not-allowed':
+        return 'この認証方法は許可されていません';
+      case 'auth/account-exists-with-different-credential':
+        return '異なる認証情報で同じメールアドレスのアカウントが存在します';
+      case 'auth/auth-domain-config-required':
+        return '認証のドメイン設定が必要です';
+      case 'auth/credential-already-in-use':
+        return '認証情報はすでに別のユーザーで使用されています';
+      case 'auth/operation-not-supported-in-this-environment':
+        return '現在の環境ではこの操作はサポートされていません';
+      case 'auth/timeout':
+        return '認証サーバーへの接続がタイムアウトしました';
+      default:
+        return 'エラーが発生しました';
+    }
+  }
+  return 'エラーが発生しました';
+};
+
+const signUpWithEmail = async (values: {
+  email: string;
+  password: string;
+}): Promise<FirebaseAuthTypes.UserCredential> => {
+  return await auth().createUserWithEmailAndPassword(
+    values.email,
+    values.password
+  );
+};
+
+const signInWithEmail = async (values: {
+  email: string;
+  password: string;
+}): Promise<FirebaseAuthTypes.UserCredential> => {
+  return await auth().signInWithEmailAndPassword(values.email, values.password);
+};
+
+export const firebaseAuth = {
+  signInWithEmail,
+  signUpWithEmail,
+  catchFirebaseAuthError,
+};

--- a/src/shared/libs/firebase/auth.ts
+++ b/src/shared/libs/firebase/auth.ts
@@ -64,8 +64,13 @@ const signInWithEmail = async (values: {
   return await auth().signInWithEmailAndPassword(values.email, values.password);
 };
 
+const signOut = async (): Promise<void> => {
+  return await auth().signOut();
+};
+
 export const firebaseAuth = {
   signInWithEmail,
   signUpWithEmail,
+  signOut,
   catchFirebaseAuthError,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2317,6 +2317,13 @@
     opencollective-postinstall "^2.0.1"
     superstruct "^0.6.2"
 
+"@react-native-firebase/auth@^18.3.1":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/@react-native-firebase/auth/-/auth-18.3.1.tgz#e0a6a3093952c1eb6d4a40a5cdd595e9fee9f77e"
+  integrity sha512-8LOVUO9BMGDGvX4uz4pJBQxGsOaLO3MFwgjuN+y9inpQRgqVm1kHQ1lsKWaS7zZLqVyYUxpY+wYx6jWL/xGwiA==
+  dependencies:
+    plist "^3.0.5"
+
 "@react-native/assets-registry@^0.72.0":
   version "0.72.0"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.72.0.tgz#c82a76a1d86ec0c3907be76f7faf97a32bbed05d"


### PR DESCRIPTION
## Overview

firebaseを使ってメールアドレスの認証を実装しました。

備忘録：https://www.notion.so/arenitez/Firebase-auth-email-setup-cb06839bd6114b3a81671e9dc045770a?pvs=4

## Reference

slack: 
figma: 
notion: https://www.notion.so/arenitez/Firebase-auth-email-setup-cb06839bd6114b3a81671e9dc045770a?pvs=4

## Before / After

| before       | after        |
| ------------ | ------------ |
| <img src=""> | <img src=""> |

